### PR TITLE
[FIX] l10n_cu_address: limpiar municipio inválido en instalación o actualización

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#macOS
+.DS_Store

--- a/l10n_cu_address/__manifest__.py
+++ b/l10n_cu_address/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name" : "Topónimos Cubanos",
-    "version" : "17.0",
+    "version" : "17.0.2.0.1",
     "author" : "Idola Odoo Team, Comunidad cubana de Odoo",
     "category": "Localization",
     "depends" : [
@@ -22,8 +22,10 @@
         'views/res_municipality_views.xml',
         'views/res_partner_views.xml',
         'security/ir.model.access.csv',
-    ],
-    'demo': [
+
+        # fix's
+        'data/res_municipalities_fix.xml'
     ],
     "auto_install": True,
+
 }

--- a/l10n_cu_address/data/res_municipalities_fix.xml
+++ b/l10n_cu_address/data/res_municipalities_fix.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <function model="res.partner"
+            name="_clean_and_fix_res_municipality_id"/>
+    </data>
+</odoo>

--- a/l10n_cu_address/models/res_partner.py
+++ b/l10n_cu_address/models/res_partner.py
@@ -1,8 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields 
+from odoo import models, fields, api
+
 
 class Partner(models.Model):
     _inherit = 'res.partner'
 
-    res_municipality_id = fields.Many2one('res.municipality', 'Municipio', domain="[('state_id', '=', state_id)]", help="Municipios de Cuba" )
+    res_municipality_id = fields.Many2one('res.municipality', 'Municipio', domain="[('state_id', '=', state_id)]",
+                                          help="Municipios de Cuba")
+
+    @api.model
+    def _clean_and_fix_res_municipality_id(self):
+        partners = self.env['res.partner'].search([]).filtered(
+            lambda p: p.res_municipality_id and p.res_municipality_id.id not in p.state_id.res_municipality_id.ids)
+        partners.write({'res_municipality_id': False})
+
+    @api.onchange('state_id')
+    def _onchange_state_id(self):
+        if self.res_municipality_id not in self.state_id.res_municipality_id:
+            self.res_municipality_id = False


### PR DESCRIPTION
Se agrega un método que se ejecuta al instalar o actualizar el módulo para limpiar el campo  si no pertenece al  del partner.

Además, se añade una validación para limpiar automáticamente el municipio si cambia el estado y el municipio actual ya no corresponde.